### PR TITLE
Require users to be enrolled in a course in order to view the lessons.

### DIFF
--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -1,10 +1,21 @@
 class LessonsController < ApplicationController
-
+  before_action :authenticate_user!
+  before_action :require_authorized_for_current_lesson, only: [:show]
 
   def show
   end
 
+
+
   private
+
+  def require_authorized_for_current_lesson
+    if ! current_user.enrolled_in?(current_lesson)
+      redirect_to course_path(current_lesson.section.course), alert: 'Please enroll in the course, before viewing the lesson.'
+    end
+  end
+
+
   helper_method :current_lesson
   def current_lesson
     @current_lesson ||= Lesson.find(params[:id])


### PR DESCRIPTION
Prevent users from viewing a lesson if they are not enrolled in the course, and redirect them back to the course detail page with an error message indicating that they must enroll before viewing the lesson.
