### PR TITLE
Disable turbolinks gem in order to get video to display properly.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'coffee-rails', '~> 4.0.0'
 gem 'jquery-rails'
 
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-gem 'turbolinks'
+# gem 'turbolinks'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,8 +173,6 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    turbolinks (2.5.3)
-      coffee-rails
     tzinfo (0.3.48)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
@@ -208,5 +206,4 @@ DEPENDENCIES
   simple_form
   sprockets (= 2.11.0)
   stripe
-  turbolinks
   uglifier (>= 1.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,7 +13,7 @@
 //= require jquery
 //= require bootstrap-sprockets
 //= require jquery_ujs
-//= require turbolinks
+
 //= require_tree .
 //
 //= require jquery-ui


### PR DESCRIPTION
Otherwise the embedded video will show up as a black bar, and the video does not show up unless the user refreshes the page.
